### PR TITLE
Fixed URL bug

### DIFF
--- a/SPBestWarmUp.ps1
+++ b/SPBestWarmUp.ps1
@@ -222,7 +222,7 @@ Function WarmUp() {
 			NavigateTo $url"_layouts/viewlsts.aspx"
 			NavigateTo $url"_vti_bin/UserProfileService.asmx"
 			NavigateTo $url"_vti_bin/sts/spsecuritytokenservice.svc"
-			NavigateTo $url"/_api/search/query?querytext='warmup'"
+			NavigateTo $url"_api/search/query?querytext='warmup'"
 		}
 		
 		# Warm Up Individual Site Collections and Sites


### PR DESCRIPTION
There was an additional forward slash on the api url.